### PR TITLE
Fix header icon crop

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -84,14 +84,12 @@
 % Needed to deal a paragraphs
 \RequirePackage{parskip}
 % Needed to deal hyperlink
-\RequirePackage{hyperref}
+\RequirePackage[hidelinks]{hyperref}
 \hypersetup{
   pdftitle={},
   pdfauthor={},
   pdfsubject={},
-  pdfkeywords={},
-  colorlinks=false,
-  allbordercolors=white
+  pdfkeywords={}
 }
 
 


### PR DESCRIPTION
hyperref box makes header social icons seem cropped. Fix by adding hidelink option to hyperref and removing color/border arguments.