### PR TITLE
Updated awesome-cv.cls

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -663,11 +663,11 @@
 \newcommand*{\makeletterclosing}{
   \vspace{3.4mm}
   \lettertextstyle{\@letterclosing} \\\\
-  \letternamestyle{\@firstname \@lastname}
+  \letternamestyle{\@firstname\ \@lastname}
   \ifthenelse{\isundefined{\@letterenclosure}}
     {\\}
     {
       \\\\\\
-      \letterenclosurestyle{\@letterenclname:  \@letterenclosure} \\
+      \letterenclosurestyle{\@letterenclname: \@letterenclosure} \\
     }
 }


### PR DESCRIPTION
Escaped the space between \@firstname and \@lastname in \makeletterclosing, so that the whitespace between the first and last name actually shows up.