### PR TITLE
Tabularwidth

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -47,7 +47,7 @@
 %                3rd party packages
 %-------------------------------------------------------------------------------
 % Needed to make fixed length table
-\RequirePackage{array}
+\RequirePackage{tabularx}
 % Needed to handle list environment
 \RequirePackage{enumitem}
 % Needed to handle text alignment
@@ -592,18 +592,16 @@
 \newenvironment{cvskills}{%
   \vspace{\acvSectionContentTopSkip}
   \vspace{-2.0mm}
-  \begin{center}
     \setlength\tabcolsep{1ex}
     \setlength{\extrarowheight}{0pt}
-    \begin{tabular*}{\textwidth}{@{\extracolsep{\fill}} r L{\textwidth * \real{0.9}}}
+    \tabularx{\textwidth}{rX}
 }{%
-    \end{tabular*}
-  \end{center}
+    \endtabularx
 }
 % Define a line of cv information(skill)
 % Usage: \cvskill{<type>}{<skillset>}
 \newcommand*{\cvskill}[2]{%
-	\skilltypestyle{#1} & \skillsetstyle{#2} \\
+	\skilltypestyle{#1} & \leavevmode\skillsetstyle{#2} \\
 }
 
 % Define an environment for cvitems(for cventry)

--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -389,6 +389,7 @@
 %                Commands for utilities
 %-------------------------------------------------------------------------------
 % Use to align an element of tabular table
+\renewcommand{\tabularxcolumn}{m}
 \newcolumntype{L}[1]{>{\raggedright\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
 \newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
 \newcolumntype{R}[1]{>{\raggedleft\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
@@ -594,7 +595,7 @@
   \vspace{-2.0mm}
     \setlength\tabcolsep{1ex}
     \setlength{\extrarowheight}{0pt}
-    \tabularx{\textwidth}{rX}
+    \tabularx{\textwidth}{r>{\raggedright\let\newline\\\arraybackslash\hspace{0pt}}X}
 }{%
     \endtabularx
 }

--- a/examples/resume.tex
+++ b/examples/resume.tex
@@ -87,7 +87,7 @@
 %	CV/RESUME CONTENT
 %	Each section is imported separately, open each file in turn to modify content
 %-------------------------------------------------------------------------------
-% \input{resume/summary.tex}
+ \input{resume/summary.tex}
 \input{resume/education.tex}
 \input{resume/experience.tex}
 \input{resume/extracurricular.tex}


### PR DESCRIPTION
Resolves #34 

The original code reads `\begin{tabular*}{\textwidth}{@{\extracolsep{\fill}} r L{\textwidth * \real{0.9}}}`. 
A table using up the complete width of the text with the following preamble: first part doesn't do anything useful at all, second part is a column which will be as wide as it's widest element, third part is a paragraph column taking up 90 percent of the textwidth (which would be much much simpler as `L{.9\textwidth}`). 

Now, if one word in the left column is very long, for example *International communication* (let's suppose that is a skill) which would take up maybe `.2` of the textwidth, giving a sum of `1.1\textwidth`. 

Solution: Use a columntype that uses up the available space: `X`.

- Replaced `array` by `tabularx` (none really needed for fixed width tables, but to resolve this issue)
- got rid of the `center` environment (vspace added, vspace removed (i left that, but maybe removing that would be  good idea) and once over vspace added for a table that is as wide as the textwidth (and hence always centered))
- `\leavevmode` because of color. likely not needed with other commit that uses the former behaviour of the column.