### PR TITLE
Added allowable optional honorific in \name

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -33,7 +33,7 @@
 % geometry and fancyhdr)
 %-------------------------------------------------------------------------------
 % Options for draft or final
-\DeclareOption{draft}{\setlength\overfullrule{5pt}}
+\DeclareOption{draft}{\setlengtfh\overfullrule{5pt}}
 \DeclareOption{final}{\setlength\overfullrule{0pt}}
 % Inherit options of article
 \DeclareOption*{%
@@ -268,7 +268,10 @@
 % Usage: \firstname{<firstname>}
 % Usage: \lastname{<lastname>}
 % Usage: \familyname{<familyname>}
-\newcommand*{\name}[2]{\def\@firstname{#1}\def\@lastname{#2}}
+
+\newcommand*{\name}[3][]{\def\@honorific{#1}\def\@firstname{#2}\def\@lastname{#3}}
+
+\newcommand*{\honorific}[1]{\def\@honorific{#1}}
 \newcommand*{\firstname}[1]{\def\@firstname{#1}}
 \newcommand*{\lastname}[1]{\def\@lastname{#1}}
 \newcommand*{\familyname}[1]{\def\@lastname{#1}}
@@ -406,8 +409,8 @@
 % Define a header for CV
 % Usage: \makecvheader
 \newcommand*{\makecvheader}{%
-  \begin{center}
-    \headerfirstnamestyle{\@firstname}\headerlastnamestyle{{}\acvHeaderNameDelim\@lastname}%
+  \begin{center} 
+    \headerfirstnamestyle{\@honorific\ \@firstname}\headerlastnamestyle{{}\acvHeaderNameDelim\@lastname}%
     \\[\acvHeaderAfterNameSkip]%
     \ifthenelse{\isundefined{\@position}}{}{\headerpositionstyle{\@position\\[\acvHeaderAfterPositionSkip]}}%
     \ifthenelse{\isundefined{\@address}}{}{\headeraddressstyle{\@address\\[\acvHeaderAfterAddressSkip]}}%


### PR DESCRIPTION
E.g., can now have:

\name[Dr.]{Virgil}{Griffith}

And have it display at the top but not at the bottom.  There may be a better way to do the spacing between the \@honorific and the \@firstname in the \headerfirstnamestyle .  I leave this to you great LaTeX master.