### PR TITLE
Fixed path to profile.png

### DIFF
--- a/examples/coverletter.tex
+++ b/examples/coverletter.tex
@@ -52,7 +52,7 @@
 %	Comment any of the lines below if they are not required
 %-------------------------------------------------------------------------------
 % Available options: circle|rectangle,edge/noedge,left/right
-\photo[circle,noedge,left]{./examples/profile}
+\photo[circle,noedge,left]{./profile}
 \name{Claud D.}{Park}
 \position{Software Engineer{\enskip\cdotp\enskip}Security Expert}
 \address{246-1002, Gwangmyeongmayrouge Apt. 86, Cheongna lime-ro, Seo-gu, Incheon-si, 404-180, Rep. of KOREA}


### PR DESCRIPTION
The example coverletter.tex now compiles. I've corrected the path to profile.png, since it was looking in a non existing folder. I believe this fixes #100   