### PR TITLE
Add optional \dateofbirth command for personal information header

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -88,6 +88,8 @@
   pdfsubject={},
   pdfkeywords={}
 }
+% Needed for \textborn
+\RequirePackage{textcomp}
 
 
 %-------------------------------------------------------------------------------
@@ -281,6 +283,10 @@
 % Usage: \email{<email adress>}
 \newcommand*{\email}[1]{\def\@email{#1}}
 
+% Defines writer's date of birth (optional)
+% Usage: \dateofbirth{<date>}
+\newcommand*{\dateofbirth}[1]{\def\@dateofbirth{#1}}
+
 % Defines writer's homepage (optional)
 % Usage: \homepage{<url>}
 \newcommand*{\homepage}[1]{\def\@homepage{#1}}
@@ -447,6 +453,13 @@
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
           \href{mailto:\@email}{\faEnvelope\acvHeaderIconSep\@email}%
+        }%
+      \ifthenelse{\isundefined{\@dateofbirth}}%
+        {}%
+        {%
+          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+          % \mbox prevents wrapping of elements
+          \mbox{\textborn{\acvHeaderIconSep\@dateofbirth}}
         }%
       \ifthenelse{\isundefined{\@homepage}}%
         {}%

--- a/examples/coverletter.tex
+++ b/examples/coverletter.tex
@@ -59,6 +59,7 @@
 
 \mobile{(+82) 10-9030-1843}
 \email{posquit0.bj@gmail.com}
+%\dateofbirth{January 1st, 1970}
 \homepage{www.posquit0.com}
 \github{posquit0}
 \linkedin{posquit0}

--- a/examples/cv.tex
+++ b/examples/cv.tex
@@ -59,6 +59,7 @@
 
 \mobile{(+82) 10-9030-1843}
 \email{posquit0.bj@gmail.com}
+%\dateofbirth{January 1st, 1970}
 \homepage{www.posquit0.com}
 \github{posquit0}
 \linkedin{posquit0}

--- a/examples/resume.tex
+++ b/examples/resume.tex
@@ -59,6 +59,7 @@
 
 \mobile{(+82) 10-9030-1843}
 \email{posquit0.bj@gmail.com}
+%\dateofbirth{January 1st, 1970}
 \homepage{www.posquit0.com}
 \github{posquit0}
 \linkedin{posquit0}


### PR DESCRIPTION
This allows the usage of e.g. `\dateofbirth{January 1st, 1970}`, which in turn adds a corresponding entry in the header.

I positioned the entry between \email and \homepage, however I am not 100% sure if this is the best place. What is your opinion on that? 

The date is actually just provided as a string which is places as-is. E.g. the user has control whether he wants "January 1st, 1970", "01.01.1970" or some other format.

I also included the command into the examples (however, I commented them out)