### PR TITLE
Allow https:// for urls in \homepage

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -88,6 +88,8 @@
   pdfsubject={},
   pdfkeywords={}
 }
+% Needed for string comparison & manipulation (e.g. in \homepage)
+\RequirePackage{xstring}
 
 
 %-------------------------------------------------------------------------------
@@ -452,7 +454,26 @@
         {}%
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
-          \href{http://\@homepage}{\faHome\acvHeaderIconSep\@homepage}%
+          \IfBeginWith{\@homepage}{http://}{%
+            % \@homepage begins with 'http://'%
+            \def\awesomecvHomepageUrl{\@homepage}%
+            % strip http:// from displayed text %
+            \def\aewsomecvHomepageText{\StrBehind{\@homepage}{http://}}%
+          }{%
+            % \@homepage does not begin with 'http://'%
+            \IfBeginWith{\@homepage}{https://}{%
+              % \@homepage begins with 'https://'%
+              \def\awesomecvHomepageUrl{\@homepage}%
+              % strip https:// from displayed text %
+              \def\aewsomecvHomepageText{\StrBehind{\@homepage}{https://}}%
+            }{%
+              % \@homepage begins with neither 'http://' nor 'https://'%
+              % -> force http scheme%
+              \def\awesomecvHomepageUrl{http://\@homepage}%
+              \def\aewsomecvHomepageText{\@homepage}%
+            }%
+          }%
+          \href{\awesomecvHomepageUrl}{\faHome\acvHeaderIconSep\aewsomecvHomepageText}%
         }%
       \ifthenelse{\isundefined{\@github}}%
         {}%


### PR DESCRIPTION
Up to now, the template always inserted a 'http://' in the url
for the \homepage{} attribute. Therefore, it was not possible
to specify 'https://example.com' as this would have resulted
in 'http://https://example.com'.

The new approach allows to specify the homepage-url in any of the
following ways (which will result in the specified strings)

| url provided to \homepage | hyperlink | displayed url-text |
|---------------------------|-----------|--------------------|
| http://example.com | http://example.com | example.com |
| https://example.com | https://example.com | example.com |
| example.com | http://example.com | example.com |

Note that the third row is equivalent to the current behavior.