### PR TITLE
Add Google Scholar link

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -314,6 +314,10 @@
 % Usage: \reddit{<reddit account>}
 \newcommand*{\reddit}[1]{\def\@reddit{#1}}
 
+% Defines writer's google scholar (optional)
+% Usage: \scholar{<user-scholar-id>}
+\newcommand*{\scholar}[1]{\def\@scholar{#1}}
+
 % Defines writer's xing (optional)
 % Usage: \xing{<xing name>}
 \newcommand*{\xing}[1]{\def\@xing{#1}}
@@ -483,6 +487,12 @@
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
           \href{https://twitter.com/\@twitter}{\faTwitter\acvHeaderIconSep\@twitter}%
+        }%
+      \ifthenelse{\isundefined{\@scholar}}%
+        {}%
+        {%
+          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+          \href{https://scholar.google.com/citations?user=\@scholar}{\faGraduationCap\acvHeaderIconSep{Google Scholar}}%
         }%
       \ifthenelse{\isundefined{\@skype}}%
         {}%

--- a/examples/coverletter.tex
+++ b/examples/coverletter.tex
@@ -66,6 +66,7 @@
 % \stackoverflow{SO-id}{SO-name}
 % \twitter{@twit}
 % \skype{skype-id}
+% \scholar{google-scholar-id}
 % \reddit{reddit-id}
 % \extrainfo{extra informations}
 

--- a/examples/cv.tex
+++ b/examples/cv.tex
@@ -65,6 +65,7 @@
 % \gitlab{gitlab-id}
 % \stackoverflow{SO-id}{SO-name}
 % \twitter{@twit}
+% \scholar{google-scholar-id}
 % \skype{skype-id}
 % \reddit{reddit-id}
 % \extrainfo{extra informations}

--- a/examples/resume.tex
+++ b/examples/resume.tex
@@ -66,6 +66,7 @@
 % \stackoverflow{SO-id}{SO-name}
 % \twitter{@twit}
 % \skype{skype-id}
+% \scholar{google-scholar-id}
 % \reddit{reddit-id}
 % \extrainfo{extra informations}
 


### PR DESCRIPTION
Adds a `\scholar` command to create a link to the user's google scholar profile in the header. The scholar IDs are ugly alphanumerics, so I've made it just print "Google Scholar" instead of the user's actual ID.