### PR TITLE
Changed cvskill env left-column to vertical top

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -387,6 +387,7 @@
 \newcolumntype{L}[1]{>{\raggedright\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
 \newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
 \newcolumntype{R}[1]{>{\raggedleft\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
+\newcolumntype{K}[1]{>{\raggedright\let\newline\\\arraybackslash\hspace{0pt}}p{#1}}
 
 % Use to draw horizontal line with specific thickness
 \def\vhrulefill#1{\leavevmode\leaders\hrule\@height#1\hfill \kern\z@}
@@ -620,23 +621,21 @@
 }
 
 % Define an environment for cvskill
-\newenvironment{cvskills}{%
-  \vspace{\acvSectionContentTopSkip}
-  \vspace{-2.0mm}
+\newenvironment{cvskills}{
   \begin{center}
     \setlength\tabcolsep{1ex}
     \setlength{\extrarowheight}{0pt}
-    \begin{tabular*}{\textwidth}{@{\extracolsep{\fill}} r L{\textwidth * \real{0.9}}}
-}{%
+    \begin{tabular*}{\textwidth}{@{\extracolsep{\fill}} r K{13.2cm}}
+}{
     \end{tabular*}
   \end{center}
 }
 % Define a line of cv information(skill)
 % Usage: \cvskill{<type>}{<skillset>}
-\newcommand*{\cvskill}[2]{%
-	\skilltypestyle{#1} & \skillsetstyle{#2} \\
+\newcommand*{\cvskill}[2]{
+  \skilltypestyle{#1} & \skillsetstyle{#2}
+  \\
 }
-
 % Define an environment for cvitems(for cventry)
 \newenvironment{cvitems}{%
   \vspace{-4.0mm}


### PR DESCRIPTION
In line with issue #136  a new column type "K" was created to vertically align the left-hand side of the text. I have also made alterations from ` L{\textwidth * \real{0.9}}}` to prevent text overflow.