### PR TITLE
Fix font-not-found error

### DIFF
--- a/fontawesome.sty
+++ b/fontawesome.sty
@@ -8,8 +8,6 @@
 % Requirements to use.
 \usepackage{fontspec}
 
-% Define shortcut to load the Font Awesome font.
-\newfontfamily{\FA}{FontAwesome}
 % Generic command displaying an icon by its name.
 \newcommand*{\faicon}[1]{{
   \FA\csname faicon@#1\endcsname


### PR DESCRIPTION
Latex gives a font-not-found error if FontAwesome is not installed globally.

The problem, as far as I can tell, is that `fontawesome.sty` declares the FontAwesome family with `\newfontfamily{\FA}{FontAwesome}`. This does not point fontspec to the proper font directory. 

However, `awesome-cv.cls` also declares the FontAwesome family with `\newfontfamily\FA[Path=\@fontdir]{FontAwesome}`. This _does_ point to the proper font directory (`\@fontdir`), so the declaration in `fontawesome.sty` is unneeded.

This closes #181