### PR TITLE
Provide a way to override the photo ID size

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -254,6 +254,10 @@
 \def\@photoedge{edge}
 \def\@photoalign{left}
 
+% Overrides the size of the photo ID if needed.
+% Usage: \photosizerectangle{<new height/width/diameter>}
+\newcommand*{\photosize}[1]{\def\@photosize{#1}}
+
 % Define writer's name
 % Usage: \name{<firstname>}{<lastname>}
 % Usage: \firstname{<firstname>}
@@ -404,9 +408,11 @@
   \newcommand*{\drawphoto}{%
     \ifthenelse{\isundefined{\@photo}}{}{%
       \newlength{\photodim}
-      \ifthenelse{\equal{\@photoshape}{circle}}%
-        {\setlength{\photodim}{1.3cm}}%
-        {\setlength{\photodim}{1.8cm}}%
+      \ifthenelse{\isundefined{\@photosize}}%
+        {\ifthenelse{\equal{\@photoshape}{circle}}%
+          {\setlength{\photodim}{1.3cm}}%
+          {\setlength{\photodim}{1.8cm}}}
+        {\setlength{\photodim}{\@photosize}}%
       \ifthenelse{\equal{\@photoedge}{edge}}%
         {\def\@photoborder{darkgray}}%
         {\def\@photoborder{none}}%


### PR DESCRIPTION
Provide a new command with the prototype `\photosizerectangle{<new height/width/diameter>`, enabling the user to override the default size of the photo ID set by the class.