### PR TITLE
Add drive command

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -273,6 +273,10 @@
 % Usage: \name{<position>}
 \newcommand*{\position}[1]{\def\@position{#1}}
 
+% Defines writer's driving license (optional)
+% Usage: \drive{<driving license>}
+\newcommand*{\drive}[1]{\def\@drive{#1}}
+
 % Defines writer's mobile (optional)
 % Usage: \mobile{<mobile number>}
 \newcommand*{\mobile}[1]{\def\@mobile{#1}}
@@ -495,6 +499,12 @@
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
           \href{https://www.reddit.com/user/\@reddit}{\faReddit\acvHeaderIconSep\@reddit}%
+        }%
+      \ifthenelse{\isundefined{\@drive}}%
+        {}%
+        {%
+          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+          \faCar\acvHeaderIconSep\@drive%
         }%
       \ifthenelse{\isundefined{\@xing}}%
         {}%

--- a/examples/cv.tex
+++ b/examples/cv.tex
@@ -67,6 +67,7 @@
 % \twitter{@twit}
 % \skype{skype-id}
 % \reddit{reddit-id}
+% \drive{Driver's License}
 % \extrainfo{extra informations}
 
 \quote{``Be the change that you want to see in the world."}

--- a/examples/resume.tex
+++ b/examples/resume.tex
@@ -67,6 +67,7 @@
 % \twitter{@twit}
 % \skype{skype-id}
 % \reddit{reddit-id}
+% \drive{Driver's License}
 % \extrainfo{extra informations}
 
 \quote{``Be the change that you want to see in the world."}


### PR DESCRIPTION
Add the command in order to notify the possession of a driver's license on CV and resume so that writer can display it.