### PR TITLE
Changed margin limit so text wont overflow

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -657,7 +657,7 @@
   \begin{center}
     \setlength\tabcolsep{1ex}
     \setlength{\extrarowheight}{0pt}
-    \begin{tabular*}{\textwidth}{@{\extracolsep{\fill}} r L{\textwidth * \real{0.9}}}
+    \begin{tabular*}{\textwidth}{@{\extracolsep{\fill}} r L{\textwidth - 4.0cm}}
 }{%
     \end{tabular*}
   \end{center}


### PR DESCRIPTION
If text is too long the text would overflow, this sets the same margin as _**cvhonors**_ section.