### PR TITLE
fix the fontspec error about \newfontfamily

### DIFF
--- a/fontawesome.sty
+++ b/fontawesome.sty
@@ -9,7 +9,7 @@
 \usepackage{fontspec}
 
 % Define shortcut to load the Font Awesome font.
-\newfontfamily{\FA}{FontAwesome}
+\newfontfamily{\FA}{FontAwesome.otf}
 % Generic command displaying an icon by its name.
 \newcommand*{\faicon}[1]{{
   \FA\csname faicon@#1\endcsname


### PR DESCRIPTION
Fix the fontspec error below; replace to `\newfontfamily{\FA}{FontAwesome.otf}`

<img width="502" alt="screen shot 2018-10-09 at 2 52 04 pm" src="https://user-images.githubusercontent.com/29731173/46649154-ec21aa00-cbd2-11e8-8c11-28faa8180fb3.png">

When compiling in local Tex (not Overleaf), this extension should be specified like [this commit](
https://github.com/posquit0/Awesome-CV/pull/236/commits/15a4a41cdad7990dbc1a1a4bf3ac1294a58904a7).