### PR TITLE
removed Sharelatex from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,7 @@ You can see [PDF](https://raw.githubusercontent.com/posquit0/Awesome-CV/master/e
 ## Quick Start
 
 * [**Edit Résumé on OverLeaf.com**](https://www.overleaf.com/latex/templates/awesome-cv/tvmzpvdjfqxp)
-* [**Edit Résumé on ShareLaTeX.com**](https://www.sharelatex.com/templates/cv-or-resume/awesome-cv)
 * [**Edit Cover Letter on OverLeaf.com**](https://www.overleaf.com/latex/templates/awesome-cv-cover-letter/pfzzjspkthbk)
-* [**Edit Cover Letter on ShareLaTeX.com**](https://www.sharelatex.com/templates/cover-letters/awesome-cv-cover-letter)
 
 **_Note:_ Above services do not guarantee up-to-date source code of Awesome CV**
 


### PR DESCRIPTION
Sharelatex no longer exists, at the moment, it just redirects to Overleaf. So the links can be removed from the Readme.