### PR TITLE
Add support for text in multiple languages

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -394,6 +394,9 @@
 % Use to execute conditional statements by checking empty string
 \newcommand*{\ifempty}[3]{\ifthenelse{\isempty{#1}}{#2}{#3}}
 
+% Provide support for text in multiple languages
+\providecommand{\cvlang}{en}
+\newcommand{\cvmultilang}[2]{\ifthenelse{\equal{#1}{\cvlang}}{#2}{}}
 
 %-------------------------------------------------------------------------------
 %                Commands for elements of CV structure


### PR DESCRIPTION
This adds support for adding text that is conditionally displayed depending on the language specified by the author in `\cvlang`.

Usage example:

```
      % ...
      \begin{cvitems} % Description(s) of tasks/responsibilities
      \item {
          \cvmultilang{en}{Talked to a rubber duck for months.}
          \cvmultilang{es}{Hable con un patito de goma durante meses.}
      }
      % ...
     \end{cvitems}
   % ...
```

To select the language either define `\cvlang` in the document

```
\renewcommand{\cvlang}{es}
```

or compile as

```
xelatex "\newcommand{\cvlang}{es}\input{resume.tex}"
```

One thing I noticed is that when adding multiple `\cvmultilang` items as children of `\cvsection` produces some odd behaviour displaying the first item and the item in the selected language. This I think is due to the way dual color style works. One way to get around it is inverting the order, such as:

```
\cvmultilang{en}{\cvsection{Work Experience}}
\cvmultilang{es}{\cvsection{Experiencia Laboral}}
\cvmultilang{de}{\cvsection{Berufliche Erfahrung}}
```