### PR TITLE
Fixes #221 "Error: Command '\FA' already defined!"

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -161,6 +161,7 @@
 %                Configuration for fonts
 %-------------------------------------------------------------------------------
 % Set the FontAwesome font to be up-to-date.
+\let\FA\relax
 \newfontfamily\FA[Path=\@fontdir]{FontAwesome}
 % Set font for header (default is Roboto)
 \newfontfamily\headerfont[


### PR DESCRIPTION
Fixes Compilation Error when commenting out the \newfont: xdvipdfmx:fatal: pdf_ref_obj(): passed invalid object.
As well als the Compilation Error: LaTeX3 Error: Command '\FA' already defined!For immediate help type H <return>.

Fixes #221 by unsetting /FA before redefining it.

In Contrary to other Pull Reqests #233 #235 and #236 i found, fontawsome works with this change.
Tested with MikTex on Windows.