### PR TITLE
Add medium and google scholar 

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -318,6 +318,14 @@
 % Usage: \xing{<xing name>}
 \newcommand*{\xing}[1]{\def\@xing{#1}}
 
+% Defines writer's medium profile (optional)
+% Usage: \medium{<medium account>}
+\newcommand*{\medium}[1]{\def\@medium{#1}}
+
+% Defines writer's google scholar profile (optional)
+% Usage: \googlescholar{<googlescholar-name>}
+\newcommand*{\googlescholar}[1]{\def\@googlescholar{#1}}
+
 % Defines writer's twitter (optional)
 % Defines writer's extra informations (optional)
 % Usage: \extrainfo{<extra informations>}
@@ -501,6 +509,18 @@
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
           \href{https://www.xing.com/profile/\@xing}{\faXingSquare\acvHeaderIconSep\@xing}
+        }%
+      \ifthenelse{\isundefined{\@medium}}%
+        {}%
+        {%
+          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+          \href{https://medium.com\\@\@medium}{\faMedium\acvHeaderIconSep\@medium}%
+        }%
+      \ifthenelse{\isundefined{\@googlescholar}}%
+        {}%
+        {%
+          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+          \href{https://scholar.google.com/citations?user=\@googlescholar}{\faGraduationCap\acvHeaderIconSep\@googlescholar}%
         }%
       \ifthenelse{\isundefined{\@extrainfo}}%
         {}%

--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -303,6 +303,7 @@
 % Usage: \linkedin{<linked-in-nick>}
 \newcommand*{\linkedin}[1]{\def\@linkedin{#1}}
 
+% Defines writer's twitter (optional)
 % Usage: \twitter{<twitter handle>}
 \newcommand*{\twitter}[1]{\def\@twitter{#1}}
 
@@ -323,10 +324,20 @@
 \newcommand*{\medium}[1]{\def\@medium{#1}}
 
 % Defines writer's google scholar profile (optional)
-% Usage: \googlescholar{<googlescholar-name>}
-\newcommand*{\googlescholar}[1]{\def\@googlescholar{#1}}
+% Usage: \googlescholar{<googlescholar userid>}{<googlescholar username>}
+% e.g.https://scholar.google.co.uk/citations?user=wpZDx1cAAAAJ
+% would be \googlescholar{wpZDx1cAAAAJ}{Name-to-display-next-icon}
+% If 'googlescholar-name' is not provided than it defaults to
+% '\firstname \lastname'
+\newcommand*{\googlescholar}[2]{%
+  \def\@googlescholarid{#1}%
+  \ifthenelse{\equal{#2}{}}{%
+    \def\@googlescholarname{\@firstname~\@lastname}%
+  }{%
+    \def\@googlescholarname{#2}%
+  }%
+}
 
-% Defines writer's twitter (optional)
 % Defines writer's extra informations (optional)
 % Usage: \extrainfo{<extra informations>}
 \newcommand*{\extrainfo}[1]{\def\@extrainfo{#1}}
@@ -516,11 +527,11 @@
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
           \href{https://medium.com\\@\@medium}{\faMedium\acvHeaderIconSep\@medium}%
         }%
-      \ifthenelse{\isundefined{\@googlescholar}}%
+      \ifthenelse{\isundefined{\@googlescholarid}}%
         {}%
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
-          \href{https://scholar.google.com/citations?user=\@googlescholar}{\faGraduationCap\acvHeaderIconSep\@googlescholar}%
+          \href{https://scholar.google.com/citations?user=\@googlescholarid}{\faGraduationCap\acvHeaderIconSep\@googlescholarname}%
         }%
       \ifthenelse{\isundefined{\@extrainfo}}%
         {}%

--- a/examples/coverletter.tex
+++ b/examples/coverletter.tex
@@ -67,6 +67,10 @@
 % \twitter{@twit}
 % \skype{skype-id}
 % \reddit{reddit-id}
+% \medium{madium-id}
+% \googlescholar{googlescholar-id}{name-to-display}
+%% \firstname and \lastname will be used
+% \googlescholar{googlescholar-id}{}
 % \extrainfo{extra informations}
 
 \quote{``Be the change that you want to see in the world."}

--- a/examples/cv.tex
+++ b/examples/cv.tex
@@ -67,6 +67,10 @@
 % \twitter{@twit}
 % \skype{skype-id}
 % \reddit{reddit-id}
+% \medium{madium-id}
+% \googlescholar{googlescholar-id}{name-to-display}
+%% \firstname and \lastname will be used
+% \googlescholar{googlescholar-id}{}
 % \extrainfo{extra informations}
 
 \quote{``Be the change that you want to see in the world."}

--- a/examples/resume.tex
+++ b/examples/resume.tex
@@ -67,6 +67,10 @@
 % \twitter{@twit}
 % \skype{skype-id}
 % \reddit{reddit-id}
+% \medium{madium-id}
+% \googlescholar{googlescholar-id}{name-to-display}
+%% \firstname and \lastname will be used
+% \googlescholar{googlescholar-id}{}
 % \extrainfo{extra informations}
 
 \quote{``Be the change that you want to see in the world."}


### PR DESCRIPTION
This PR adds optional commands to show/link accounts on [Medium](https://medium.com/) and [Google Scholar](https://scholar.google.co.uk/)

![cv_1](https://user-images.githubusercontent.com/16823400/50423961-78e41780-0854-11e9-80cf-161199087a72.png)

1. `\medium{<USER_NAME>}`: addresses **issue #250**

    Parameter `<USER_NAME>` is defined by a blog link `https://medium.com/@<USER_NAME>`. This command uses `\faMedium` from the `fontawesome.sty`, which corresponds to an older [icon](https://www.logolynx.com/topic/medium#&gid=1&pid=16) of Medium.

2. `\googlescholar{<USER_ID>}{<USER_NAME>}`: targets users with academical record.

    The first parameter, `<USER_ID>`, is used for hyperlink. The second, `<USER_NAME>`,  is displayed in the pdf document. This command uses `\faGraduationCap` from the `fontawesome.sty`.
    Since the value of parameter `<USER_ID>` in a link to user's profile is uniquely assigned by google, e.g. `https://scholar.google.com/citations?user=<USER_ID>&hl=en`, therefore, it is just a bunch of characters and not meaningful. Thus, you can specify `<USER_NAME>` or leave it empty which would default to `\firstname{<NAME>}` and `\lastname{<SURNAME>}` or equivalently `\name{<NAME>}{<SURNAME>}`.