### PR TITLE
Fix fontspec error: "font-not-found"

### DIFF
--- a/fontawesome.sty
+++ b/fontawesome.sty
@@ -8,8 +8,6 @@
 % Requirements to use.
 \usepackage{fontspec}
 
-% Define shortcut to load the Font Awesome font.
-\newfontfamily{\FA}{FontAwesome}
 % Generic command displaying an icon by its name.
 \newcommand*{\faicon}[1]{{
   \FA\csname faicon@#1\endcsname


### PR DESCRIPTION
The `\FA` font family is declared both in `fontawesome.sty` (without a path) and in `awesome-cv.cls` (with a path). This confuses xelatex and produces a font-not-found error if Font Awesome is not installed globally. It is fixed by only using the declaration with a path.

This closes #181 and #221.

This is an alternative to #246. That PR un-defines the first `\FA` before redefining it. This PR simply removes the first definition.

**EDIT:** It looks like I tried to push this same change about a year ago in #191. I'll close that in favor of this one since the commit message is better and it's based on the current master.

Here is the full output, including the error, when calling `make examples` on current master:

```
$ make examples
xelatex -output-directory=examples examples/coverletter.tex
This is XeTeX, Version 3.14159265-2.6-0.99999 (TeX Live 2018) (preloaded format=xelatex)
 restricted \write18 enabled.
entering extended mode
(./examples/coverletter.tex
LaTeX2e <2018-04-01> patch level 2
Babel <3.18> and hyphenation patterns for 84 language(s) loaded.
(examples/awesome-cv.cls
Document Class: awesome-cv 2017/02/05 v1.6.1 Awesome Curriculum Vitae Class
(/usr/local/texlive/2018/texmf-dist/tex/latex/base/article.cls
Document Class: article 2014/09/29 v1.4h Standard LaTeX document class
(/usr/local/texlive/2018/texmf-dist/tex/latex/base/size11.clo))
(/usr/local/texlive/2018/texmf-dist/tex/latex/tools/array.sty)
(/usr/local/texlive/2018/texmf-dist/tex/latex/enumitem/enumitem.sty)
(/usr/local/texlive/2018/texmf-dist/tex/latex/ms/ragged2e.sty
(/usr/local/texlive/2018/texmf-dist/tex/latex/ms/everysel.sty))
(/usr/local/texlive/2018/texmf-dist/tex/latex/geometry/geometry.sty
(/usr/local/texlive/2018/texmf-dist/tex/latex/graphics/keyval.sty)
(/usr/local/texlive/2018/texmf-dist/tex/generic/oberdiek/ifpdf.sty)
(/usr/local/texlive/2018/texmf-dist/tex/generic/oberdiek/ifvtex.sty)
(/usr/local/texlive/2018/texmf-dist/tex/generic/ifxetex/ifxetex.sty))
(/usr/local/texlive/2018/texmf-dist/tex/latex/fancyhdr/fancyhdr.sty)
(/usr/local/texlive/2018/texmf-dist/tex/latex/xcolor/xcolor.sty
(/usr/local/texlive/2018/texmf-dist/tex/latex/graphics-cfg/color.cfg)
(/usr/local/texlive/2018/texmf-dist/tex/latex/graphics-def/xetex.def))
(/usr/local/texlive/2018/texmf-dist/tex/latex/xifthen/xifthen.sty
(/usr/local/texlive/2018/texmf-dist/tex/latex/tools/calc.sty)
(/usr/local/texlive/2018/texmf-dist/tex/latex/base/ifthen.sty)
(/usr/local/texlive/2018/texmf-dist/tex/latex/ifmtarg/ifmtarg.sty))
(/usr/local/texlive/2018/texmf-dist/tex/latex/etoolbox/etoolbox.sty)
(/usr/local/texlive/2018/texmf-dist/tex/latex/setspace/setspace.sty)
(/usr/local/texlive/2018/texmf-dist/tex/latex/fontspec/fontspec.sty
(/usr/local/texlive/2018/texmf-dist/tex/latex/l3packages/xparse/xparse.sty
(/usr/local/texlive/2018/texmf-dist/tex/latex/l3kernel/expl3.sty
(/usr/local/texlive/2018/texmf-dist/tex/latex/l3kernel/expl3-code.tex)
(/usr/local/texlive/2018/texmf-dist/tex/latex/l3kernel/l3xdvipdfmx.def)))
(/usr/local/texlive/2018/texmf-dist/tex/latex/fontspec/fontspec-xetex.sty
(/usr/local/texlive/2018/texmf-dist/tex/latex/base/fontenc.sty
(/usr/local/texlive/2018/texmf-dist/tex/latex/base/tuenc.def))
(/usr/local/texlive/2018/texmf-dist/tex/latex/fontspec/fontspec.cfg)))
(/usr/local/texlive/2018/texmf-dist/tex/latex/unicode-math/unicode-math.sty
(/usr/local/texlive/2018/texmf-dist/tex/latex/unicode-math/unicode-math-xetex.s
ty
(/usr/local/texlive/2018/texmf-dist/tex/latex/l3packages/l3keys2e/l3keys2e.sty)
 (/usr/local/texlive/2018/texmf-dist/tex/latex/filehook/filehook.sty)
(/usr/local/texlive/2018/texmf-dist/tex/latex/base/fix-cm.sty
(/usr/local/texlive/2018/texmf-dist/tex/latex/base/ts1enc.def))
(/usr/local/texlive/2018/texmf-dist/tex/latex/unicode-math/unicode-math-table.t
ex))) (examples/fontawesome.sty
kpathsea: Running mktextfm FontAwesome
/usr/local/texlive/2018/texmf-dist/web2c/mktexnam: Could not map source abbreviation F for FontAwesome.
/usr/local/texlive/2018/texmf-dist/web2c/mktexnam: Need to update /usr/local/texlive/2018/texmf-dist/fonts/map/fontname/special.map?
mktextfm: Running mf-nowin -progname=mf \mode:=ljfour; mag:=1; nonstopmode; input FontAwesome
This is METAFONT, Version 2.7182818 (TeX Live 2018) (preloaded base=mf)


kpathsea: Running mktexmf FontAwesome
! I can't find file `FontAwesome'.
<*> ...our; mag:=1; nonstopmode; input FontAwesome

Please type another input file name
! Emergency stop.
<*> ...our; mag:=1; nonstopmode; input FontAwesome

Transcript written on mfput.log.
grep: FontAwesome.log: No such file or directory
mktextfm: `mf-nowin -progname=mf \mode:=ljfour; mag:=1; nonstopmode; input FontAwesome' failed to make FontAwesome.tfm.
kpathsea: Appending font creation commands to missfont.log.


!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!
! fontspec error: "font-not-found"
!
! The font "FontAwesome" cannot be found.
!
! See the fontspec documentation for further information.
!
! For immediate help type H <return>.
!...............................................

l.12 \newfontfamily{\FA}{FontAwesome}

?
```