### PR TITLE
setting default fontdir to blank value

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -94,7 +94,7 @@
 %                Configuration for directory locations
 %-------------------------------------------------------------------------------
 % Configure a directory location for fonts(default: 'fonts/')
-\newcommand*{\fontdir}[1][fonts/]{\def\@fontdir{#1}}
+\newcommand*{\fontdir}[1][]{\def\@fontdir{#1}}
 \fontdir
 
 


### PR DESCRIPTION
this modification allows the user to actually set a custom
fonts folder or use them as system ones if properly cached