### PR TITLE
Link mobile phone number in header

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -458,7 +458,7 @@
       \ifthenelse{\isundefined{\@mobile}}%
         {}%
         {%
-          \faMobile\acvHeaderIconSep\@mobile%
+          \href{tel:\@mobile}{\faMobile\acvHeaderIconSep\@mobile}%
           \setbool{isstart}{false}%
         }%
       \ifthenelse{\isundefined{\@email}}%


### PR DESCRIPTION
Enables direct calling e.g. on resume's recipients mobile phone.
For more info see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Creating_a_phone_link

I think this is a nice little addition, which I have added for my own resume. What do you think?