### PR TITLE
Make Usage section a bit more straight-forward.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ You can [install TeX from upstream](http://tex.stackexchange.com/q/1092) (recomm
 
 #### Usage
 
-At a command prompt, run
+At a command prompt, run (note that ``$`` is shell prompt)
 
 ```bash
-$ xelatex {your-cv}.tex
+$ cd examples/
+$ xelatex cv.tex
 ```
 
-This should result in the creation of ``{your-cv}.pdf``
-
+This should result in the creation of ``cv.pdf``, substitute ``cv.tex`` with ``{your-cv}.tex`` in the above command.
 
 ## Credit
 


### PR DESCRIPTION
Hi,

Thanks for this repo.

I'm a newbie of LaTeX, it takes me a few minutes to figure out that `xelatex {your-cv}.tex` in README means to compile it with `cv.tex` or `resume.tex` in `examples/` dir.
At first I think it's ok to run with every single .tex files there, which of course leads to compilation errors.

So I think it's better to take the exact file as an example in README.