### PR TITLE
Fix cvsubentry

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -622,7 +622,7 @@
   \begin{tabular*}{\textwidth}{@{\extracolsep{\fill}} L{\textwidth - 4.5cm} R{4.5cm}}
     \setlength\leftskip{0.2cm}
     \subentrytitlestyle{#2} & \ifthenelse{\equal{#1}{}}
-      {\subentrydatestyle{#3}}{}
+      {\subentrydatestyle{#3}}{} \\
     \ifthenelse{\equal{#1}{}}
       {}
       {\subentrypositionstyle{#1} & \subentrydatestyle{#3} \\}

--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -623,12 +623,14 @@
     \setlength\leftskip{0.2cm}
     \subentrytitlestyle{#2} & \ifthenelse{\equal{#1}{}}
       {\subentrydatestyle{#3}}{} \\
-    \ifthenelse{\equal{#1}{}}
-      {}
-      {\subentrypositionstyle{#1} & \subentrydatestyle{#3} \\}
-    \ifthenelse{\equal{#4}{}}
-      {}
-      {\multicolumn{2}{L{17.0cm}}{\subdescriptionstyle{#4}} \\}
+    \ifx\relax#1\relax
+    \else
+      \subentrypositionstyle{#1} & \subentrydatestyle{#3} \\
+    \fi
+    \ifx\relax#4\relax
+    \else
+      \multicolumn{2}{L{17.0cm}}{\subdescriptionstyle{#4}} \\
+    \fi
   \end{tabular*}
 }
 


### PR DESCRIPTION
Fix for issue #29 

Adds a missing double-backslash to signify the end of the first table row and replaces the ifthenelse construction with a ifx construction to check for empty arguments without breaking the tabular