### PR TITLE
Fixes LaTeX compile error with FontAwesome font

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -161,7 +161,7 @@
 %                Configuration for fonts
 %-------------------------------------------------------------------------------
 % Set the FontAwesome font to be up-to-date.
-\newfontfamily\FA[Path=\@fontdir]{FontAwesome}
+\setfontfamily\FA[Path=\@fontdir]{FontAwesome}
 % Set font for header (default is Roboto)
 \newfontfamily\headerfont[
   Path=\@fontdir,


### PR DESCRIPTION
The `\setfontfamily\FA` command causes a compilation error using xelatex. This small fix makes sure that the document compiles again.

The compilation error:

```
$ xelatex resume.tex
...
! LaTeX3 Error: Command '\FA' already defined!

For immediate help type H <return>.
 ...

l.166 \newfontfamily
                    \headerfont[
?
```