### PR TITLE
Fix text color after lettersection.

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -730,6 +730,7 @@
   \lettersectionstyle{#1}
   \color{gray}\vhrulefill{0.9pt}
   \par\nobreak\addvspace{0.4ex}
+  \lettertextstyle
 }
 
 % Define a title of the cover letter


### PR DESCRIPTION
Resolves #382. Specifically, this stops the `\color{gray}\vhrulefill{0.9pt}` contained in `\lettersection{}` from carrying `\color{gray}` forward in the cvletter environment and impacting text color in the paragraph that follows.