### PR TITLE
Use the latest official TexLive release for CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: thomasweise/texlive
+    container: texlive/texlive:latest
 
     steps:
     - name: Checkout repo


### PR DESCRIPTION
Hi!

This PR switches CI build container to the latest official TexLive release, 2021, from the unofficial build of 2020 which is currently used. Using the latest official release should help minimize compatibility issues with Tex environments.

```console
$ podman run docker.io/thomasweise/texlive tlmgr version        
Welcome to the TeX Live docker container thomasweise/texlive.
GitHub   : http://www.github.com/thomasWeise/docker-texlive
DockerHub: http://hub.docker.com/r/thomasweise/texlive
The command 'tlmgr' with arguments 'version' was specified. Now executing this command.
tlmgr revision 55369 (2020-06-01 02:32:00 +0200)
tlmgr using installation: /usr/share/texlive
Successfully finished executing command 'tlmgr' with arguments 'version'.
Now exiting container.
```

```console
$ podman run docker.io/texlive/texlive:latest  tlmgr version
tlmgr revision 60693 (2021-10-04 04:24:25 +0200)
tlmgr using installation: /usr/local/texlive/2021
TeX Live (https://tug.org/texlive) version 2021
```