### PR TITLE
Fix broken GitHub Actions workflows

### DIFF
--- a/.github/workflows/pull-request-labeler.yaml
+++ b/.github/workflows/pull-request-labeler.yaml
@@ -1,7 +1,7 @@
 name: Label Pull Requests
 
 on:
-- pull_request
+- pull_request_target
 
 jobs:
   label-pr:

--- a/.github/workflows/welcome.yaml
+++ b/.github/workflows/welcome.yaml
@@ -1,0 +1,31 @@
+name: Welcome for First Issue or Pull Request
+
+on:
+  pull_request_target:
+    types:
+    - opened
+  issues:
+    types:
+    - opened
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Welcome for First Issue or Pull Request
+      uses: actions/first-interaction@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: |
+          ### :wave: Welcome! Looks like this is your first issue.
+
+          Hey, thanks for your contribution! Please give us a bit of time to review it. 😄
+
+          **Be sure to follow the issue template!**
+        pr-message: |
+          ### :wave: Welcome! Looks like this is your first pull request.
+
+          Hey, thanks for your contribution! Please give us a bit of time to review it. 😄
+
+          **Please check out our contributing guidelines.**

--- a/.github/workflows/welcome.yaml
+++ b/.github/workflows/welcome.yaml
@@ -21,11 +21,7 @@ jobs:
           ### :wave: Welcome! Looks like this is your first issue.
 
           Hey, thanks for your contribution! Please give us a bit of time to review it. 😄
-
-          **Be sure to follow the issue template!**
         pr-message: |
           ### :wave: Welcome! Looks like this is your first pull request.
 
           Hey, thanks for your contribution! Please give us a bit of time to review it. 😄
-
-          **Please check out our contributing guidelines.**


### PR DESCRIPTION
### Background

- #400
- `pull-request-labeler` and `welcome` action are not working for PRs by outside contributors.
  - No permission to write to the repository


### Problem Solving

- `pull_request_target` event type has read and write permission to the repository.
  - https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target