### PR TITLE
VS Code integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,15 +7,21 @@
 *.fls
 *.out
 *.toc
+*.bbl
+*.bcf
+*.blg
 
 ## Intermediate documents:
 *.dvi
 *-converted-to.*
 
 ### Editor ###
-## Vim & Emacs temp files:
+## Vim, Emacs, VS Code temp files:
 .*sw[op]
 *~
+*.run.xml
+*.fdb_latexmk
+*.synctex.gz
 
 ### Mac OS X ###
 ## Mac OS X metadata files:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "James-Yu.latex-workshop"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "latex-workshop.latex.recipe.default": "latexmk (lualatex)"
+}


### PR DESCRIPTION
Not sure if this is within the scope of this repo, so feel free to close if not. 

VSCode users, especially those who have enabled the option "compile on document save", have to manually compile and/or ignore the compilation errors from latexmk.

The errors are due to latexmk using pdflatex by default. This PR sets the default build command for vscode to the predefined build option `latexmk (lualatex)`, making this repo work out of the gate with vscode.

## Additional notes

The recommended exntesion is [this](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop), which is the most popular and widely used LaTex extension in VSCode by a long shot.
