### PR TITLE
Updated to use Font Awesome 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ In either case, this should result in the creation of ``{your-cv}.pdf``
 
 [**LaTeX**](https://www.latex-project.org) is a fantastic typesetting program that a lot of people use these days, especially the math and computer science people in academia.
 
-[**LaTeX FontAwesome**](https://github.com/furl/latex-fontawesome) is bindings for FontAwesome icons to be used in XeLaTeX.
+[**FontAwesome6 LaTeX Package**](https://github.com/braniii/fontawesome) is a LaTeX package that provides access to the [Font Awesome 6](https://fontawesome.com/v6/icons) icon set.
 
 [**Roboto**](https://github.com/google/roboto) is the default font on Android and ChromeOS, and the recommended font for Google’s visual language, Material Design.
 

--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -314,6 +314,10 @@
 % Usage: \twitter{<twitter handle>}
 \newcommand*{\twitter}[1]{\def\@twitter{#1}}
 
+% Defines writer's x (formerly twitter) (optional)
+% Usage: \x{<x account>}
+\newcommand*{\x}[1]{\def\@x{#1}}
+
 % Defines writer's Mastodon (optional)
 % Usage: \mastodon{<instance>}{<mastodon-nick>}
 \newcommand*{\mastodon}[2]{\def\@mastodoninstance{#1}\def\@mastodonname{#2}}
@@ -548,6 +552,12 @@
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
           \href{https://twitter.com/\@twitter}{\faTwitter\acvHeaderIconSep\@twitter}%
+        }%
+      \ifthenelse{\isundefined{\@x}}%
+        {}%
+        {%
+          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+          \href{https://x.com/\@x}{\faXTwitter\acvHeaderIconSep\@x}%
         }%
       \ifthenelse{\isundefined{\@mastodonname}}%
         {}%

--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -75,7 +75,7 @@
 % Needed to manage math fonts
 \RequirePackage{unicode-math}
 % Needed to use icons from font-awesome
-\RequirePackage{fontawesome5}
+\RequirePackage{fontawesome6}
 \RequirePackage{roboto}
 \RequirePackage[default,opentype]{sourcesanspro}
 % Needed for the photo ID
@@ -499,19 +499,19 @@
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
           % \mbox prevents wrapping of elements%
-          \mbox{\faBirthdayCake\acvHeaderIconSep\@dateofbirth}%
+          \mbox{\faCakeCandles\acvHeaderIconSep\@dateofbirth}%
         }%
       \ifthenelse{\isundefined{\@homepage}}%
         {}%
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
-          \href{http://\@homepage}{\faHome\acvHeaderIconSep\@homepage}%
+          \href{http://\@homepage}{\faHouseChimney\acvHeaderIconSep\@homepage}%
         }%
       \ifthenelse{\isundefined{\@github}}%
         {}%
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
-          \href{https://github.com/\@github}{\faGithubSquare\acvHeaderIconSep\@github}%
+          \href{https://github.com/\@github}{\faSquareGithub\acvHeaderIconSep\@github}%
         }%
       \ifthenelse{\isundefined{\@gitlab}}%
         {}%
@@ -577,7 +577,7 @@
         {}%
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
-          \href{https://www.xing.com/profile/\@xing}{\faXingSquare\acvHeaderIconSep\@xing}
+          \href{https://www.xing.com/profile/\@xing}{\faSquareXing\acvHeaderIconSep\@xing}
         }%
       \ifthenelse{\isundefined{\@medium}}%
         {}%

--- a/examples/coverletter.tex
+++ b/examples/coverletter.tex
@@ -64,6 +64,7 @@
 % \gitlab{gitlab-id}
 % \stackoverflow{SO-id}{SO-name}
 % \twitter{@twit}
+% \x{x-id}
 % \skype{skype-id}
 % \reddit{reddit-id}
 % \medium{madium-id}

--- a/examples/cv.tex
+++ b/examples/cv.tex
@@ -64,6 +64,7 @@
 % \gitlab{gitlab-id}
 % \stackoverflow{SO-id}{SO-name}
 % \twitter{@twit}
+% \x{x-id}
 % \skype{skype-id}
 % \reddit{reddit-id}
 % \medium{medium-id}

--- a/examples/resume.tex
+++ b/examples/resume.tex
@@ -64,6 +64,7 @@
 % \gitlab{gitlab-id}
 % \stackoverflow{SO-id}{SO-name}
 % \twitter{@twit}
+% \x{x-id}
 % \skype{skype-id}
 % \reddit{reddit-id}
 % \medium{madium-id}


### PR DESCRIPTION
Hi,

This pull request adds latex commands for **Font Awesome 6.1.1** free icons (inspired by #258 and #235).

Since there is no official FontAwesome6 package yet, I created a node application ([latex-fontawesome](https://github.com/xaviermawet/latex-fontawesome/tree/develop)) that consumes the [Font Awesome GraphQL API](https://fontawesome.com/docs/apis/graphql/get-started) to get icons metadata and generate definitions (`sty` file). Logic is based on [plorcupine's latex-fontawesome](https://github.com/plorcupine/latex-fontawesome) project.

Steps in order to use icons from so-generated `fontawesome6.sty` file:
1. Use search on the official [website](https://fontawesome.com/icons?d=gallery) to find icon by name or related tags.
2. Use unicode of the desired icon to search for latex definition in `fontawesome6.sty`.
3. Copy and paste the associated definition in your latex document.