### PR TITLE
Solves Warning: File `cv.out' has changed #423

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -80,14 +80,15 @@
 % Needed to deal a paragraphs
 \RequirePackage{parskip}
 % Needed to deal hyperlink
-\RequirePackage[hidelinks,unicode]{hyperref}
+\RequirePackage[hidelinks,unicode,pdfpagelabels=false]{hyperref}
 \hypersetup{%
   pdftitle={},
   pdfauthor={},
   pdfsubject={},
   pdfkeywords={}
 }
-
+% Solves issues Warning: File `cv.out' has changed
+\RequirePackage{bookmark}
 
 %-------------------------------------------------------------------------------
 %                Configuration for directory locations


### PR DESCRIPTION
As discussed in the issue 423 [1] the TeX file has to be re-rendered twice
Because of the above-mentioned warning.

This patch fixes this and an additional warning causing a double rendering

[1] — https://github.com/posquit0/Awesome-CV/issues/423