### PR TITLE
\cvhonor: Omit comma if honortitle is empty

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -692,7 +692,7 @@
 % Define a line of cv information(honor, award or something else)
 % Usage: \cvhonor{<position>}{<title>}{<location>}{<date>}
 \newcommand*{\cvhonor}[4]{%
-  \honordatestyle{#4} & \honorpositionstyle{#1}, \honortitlestyle{#2} & \honorlocationstyle{#3} \\
+  \honordatestyle{#4} & \honorpositionstyle{#1}\ifthenelse{\equal{#2}{}}{}{,} \honortitlestyle{#2} & \honorlocationstyle{#3} \\
 }
 
 % Define an environment for cvskill


### PR DESCRIPTION
Needed this for my own, figured someone else might want it as well

It's the first way I thought of, feel free to push directly to the branch if there's a better way to do it