### PR TITLE
Fix example cv path to certificates.tex

### DIFF
--- a/examples/cv.tex
+++ b/examples/cv.tex
@@ -100,7 +100,7 @@
 \input{cv/experience.tex}
 \input{cv/extracurricular.tex}
 \input{cv/honors.tex}
-\input{resume/certificates.tex}
+\input{cv/certificates.tex}
 \input{cv/presentation.tex}
 \input{cv/writing.tex}
 \input{cv/committees.tex}


### PR DESCRIPTION
Thanks @posquit0 for the Awesome project.

I noticed this inconsistency in the example template. Both the `resume` and `cv` folders contain a certificates.tex file so seems more appropriate they each use their respective one instead of both using the `resume/certificates.tex`