### PR TITLE
Add comma after position only if title is not empty

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -692,7 +692,7 @@
 % Define a line of cv information(honor, award or something else)
 % Usage: \cvhonor{<position>}{<title>}{<location>}{<date>}
 \newcommand*{\cvhonor}[4]{%
-  \honordatestyle{#4} & \honorpositionstyle{#1}, \honortitlestyle{#2} & \honorlocationstyle{#3} \\
+  \honordatestyle{#4} & \honorpositionstyle{#1}\ifempty{#2}{}{,} \honortitlestyle{#2} & \honorlocationstyle{#3} \\
 }
 
 % Define an environment for cvskill


### PR DESCRIPTION
Make comma conditional that are used after position part in an honor entry. Comma will disappear if the title is empty.

Fixes #480.