### PR TITLE
fix cvsection n < 3 issues

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -154,12 +154,6 @@
 \newbool{acvSectionColorHighlight}
 \setbool{acvSectionColorHighlight}{true}
 
-% Awesome section color
-\def\@sectioncolor#1#2#3{%
-  \ifbool{acvSectionColorHighlight}{{\color{awesome}#1#2#3}}{#1#2#3}%
-}
-
-
 %-------------------------------------------------------------------------------
 %                Configuration for fonts
 %-------------------------------------------------------------------------------
@@ -181,7 +175,14 @@
 \newcommand*{\headersocialstyle}[1]{{\fontsize{6.8pt}{1em}\headerfont\color{text} #1}}
 \newcommand*{\headerquotestyle}[1]{{\fontsize{9pt}{1em}\bodyfont\itshape\color{darktext} #1}}
 \newcommand*{\footerstyle}[1]{{\fontsize{8pt}{1em}\footerfont\scshape\color{lighttext} #1}}
-\newcommand*{\sectionstyle}[1]{{\fontsize{16pt}{1em}\bodyfont\bfseries\color{text}\@sectioncolor #1}}
+\newcommand*{\sectionstyleface}[1]{{\fontsize{16pt}{1em}\bodyfont\bfseries #1}}
+\newcommand*{\sectionstyle}[1]{%
+  \def\@acvSectionTmp{#1}
+  \ifthenelse{\boolean{acvSectionColorHighlight}}{%
+    \StrSplit{\@acvSectionTmp}{3}{\acvSectionStringAwesome}{\acvSectionStringPlain}%
+      \color{awesome}\sectionstyleface{\acvSectionStringAwesome%
+      \color{text}{\acvSectionStringPlain}}}%
+      {\color{text}\sectionstyleface{\@acvSectionTmp}}}
 \newcommand*{\subsectionstyle}[1]{{\fontsize{12pt}{1em}\bodyfont\scshape\textcolor{text}{#1}}}
 \newcommand*{\paragraphstyle}{\fontsize{9pt}{1em}\bodyfontlight\upshape\color{text}}
 
@@ -210,7 +211,14 @@
 \newcommand*{\skillsetstyle}[1]{{\fontsize{9pt}{1em}\bodyfontlight\color{text} #1}}
 
 % For elements of the cover letter
-\newcommand*{\lettersectionstyle}[1]{{\fontsize{14pt}{1em}\bodyfont\bfseries\color{text}\@sectioncolor #1}}
+\newcommand*{\lettersectionstyleface}[1]{{\fontsize{14pt}{1em}\bodyfont\bfseries #1}}
+\newcommand*{\lettersectionstyle}[1]{%
+  \def\@acvLetterSectionTmp{#1}
+  \ifthenelse{\boolean{acvSectionColorHighlight}}{%
+    \StrSplit{\@acvLetterSectionTmp}{3}{\acvLetterSectionStringAwesome}{\acvLetterSectionStringPlain}%
+      \color{awesome}\sectionstyleface{\acvLetterSectionStringAwesome%
+      \color{text}{\acvLetterSectionStringPlain}}}%
+      {\color{text}\lettersectionstyleface{\@acvLetterSectionTmp}}}
 \newcommand*{\recipientaddressstyle}[1]{{\fontsize{9pt}{1em}\bodyfont\scshape\color{graytext} #1}}
 \newcommand*{\recipienttitlestyle}[1]{{\fontsize{11pt}{1em}\bodyfont\bfseries\color{darktext} #1}}
 \newcommand*{\lettertitlestyle}[1]{{\fontsize{10pt}{1em}\bodyfontlight\bfseries\color{darktext} \underline{#1}}}


### PR DESCRIPTION
Fixes issue with cvsection shorter than 3 characters failing to build. See issues #471 and #473 Also resolves issues with spaces not being tokenized so `~` or `\ ` are no longer needed. Also allows for nameless cvsections, e.g. `\cvsection{}`.

<img width="891" alt="Screenshot 2024-06-28 at 5 24 39 PM" src="https://github.com/posquit0/Awesome-CV/assets/1300336/7e2cf5fd-da27-4a30-b5d2-4687488335c3">
