### PR TITLE
Allow for empty cventry arguments

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -668,6 +668,10 @@
   \begin{tabular*}{\textwidth}{@{\extracolsep{\fill}} L{\textwidth - 4.5cm} R{4.5cm}}
     \ifempty{#2#3}
       {\entrypositionstyle{#1} & \entrydatestyle{#4} \\}
+    \ifempty{#1#4}
+      {\entrytitlestyle{#2} & \entrylocationstyle{#3} \\}
+    \ifempty{#1#3}
+      {\entrytitlestyle{#2} & \entrydatestyle{#4} \\}
       {\entrytitlestyle{#2} & \entrylocationstyle{#3} \\
       \entrypositionstyle{#1} & \entrydatestyle{#4} \\}
     \ifstrempty{#5}


### PR DESCRIPTION
Adds support for empty position + date and empty position + location which should resolve issue #476, #327, #249, #247, #155 and addresses the issues addressed in unmerged (and conflicted) #428.

<img width="941" alt="Screenshot 2024-06-28 at 6 44 50 PM" src="https://github.com/posquit0/Awesome-CV/assets/1300336/121bfa8c-01d1-48bc-8d2c-1e2fa0787e57">

Edit: And possible bug from #499 couldn't be reproduced, so resolves that too?

<img width="923" alt="Screenshot 2024-06-28 at 7 06 01 PM" src="https://github.com/posquit0/Awesome-CV/assets/1300336/628e3d7e-2222-4d1d-abdb-bfc06ca2ce71">
