### PR TITLE
fix: spacing issue with cvitems (#532)

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -746,7 +746,7 @@
 }{%
   \end{itemize}
   \end{justify}
-  \vspace{-4.0mm}
+  \vspace{1.0mm}
 }
 
 


### PR DESCRIPTION
Closes #532

This needs testing with previous LaTeX distributions, but I can confirm that the output from MiKTeX is identical to the PDF file that was generated before the bug emerged with the distribution update.