### PR TITLE
Fix link prefix for homepage

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -501,7 +501,7 @@
         {}%
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
-          \href{http://\@homepage}{\faHome\acvHeaderIconSep\@homepage}%
+          \href{\@homepage}{\faHome\acvHeaderIconSep\@homepage}%
         }%
       \ifthenelse{\isundefined{\@github}}%
         {}%


### PR DESCRIPTION
If the user supplies a http/https prefix then the homepage link breaks because of it. Do not supply a prefix and let the user choose.