### PR TITLE
Add support for WhatsApp links

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -272,6 +272,20 @@
   \StrDel{\@teluri}{)}[\@teluri]%
 }
 
+% Defines writer's WhatsApp (optional)
+% Usage: \whatsapp{<mobile number>}
+\newcommand*{\whatsapp}[1]
+{
+  \def\@whatsapp{#1}
+  \def\@wameuri{https://wa.me/\@whatsapp}
+  % Strip unwanted characters
+  \StrDel{\@wameuri}{ }[\@wameuri]%
+  \StrDel{\@wameuri}{+}[\@wameuri]%
+  \StrDel{\@wameuri}{-}[\@wameuri]%
+  \StrDel{\@wameuri}{(}[\@wameuri]%
+  \StrDel{\@wameuri}{)}[\@wameuri]%
+}
+
 % Defines writer's email (optional)
 % Usage: \email{<email address>}
 \newcommand*{\email}[1]{\def\@email{#1}}
@@ -487,6 +501,12 @@
         {%
           \href{\@teluri}{\faMobile\acvHeaderIconSep\@mobile}%
           \setbool{isstart}{false}%
+        }%
+      \ifthenelse{\isundefined{\@whatsapp}}%
+        {}%
+        {%
+          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+          \href{\@wameuri}{\faWhatsappSquare\acvHeaderIconSep\@whatsapp}%
         }%
       \ifthenelse{\isundefined{\@email}}%
         {}%

--- a/examples/coverletter.tex
+++ b/examples/coverletter.tex
@@ -56,6 +56,7 @@
 \address{235, World Cup buk-ro, Mapo-gu, Seoul, 03936, Republic of Korea}
 
 \mobile{(+82) 10-9030-1843}
+%\whatsapp{(+82) 10-9030-1843}
 \email{posquit0.bj@gmail.com}
 %\dateofbirth{January 1st, 1970}
 \homepage{www.posquit0.com}

--- a/examples/cv.tex
+++ b/examples/cv.tex
@@ -56,6 +56,7 @@
 \address{235, World Cup buk-ro, Mapo-gu, Seoul, 03936, Republic of Korea}
 
 \mobile{(+82) 10-9030-1843}
+%\whatsapp{(+82) 10-9030-1843}
 \email{posquit0.bj@gmail.com}
 %\dateofbirth{January 1st, 1970}
 \homepage{www.posquit0.com}

--- a/examples/resume.tex
+++ b/examples/resume.tex
@@ -56,6 +56,7 @@
 \address{235, World Cup buk-ro, Mapo-gu, Seoul, 03936, Republic of Korea}
 
 \mobile{(+82) 10-9030-1843}
+%\whatsapp{(+82) 10-9030-1843}
 \email{posquit0.bj@gmail.com}
 %\dateofbirth{January 1st, 1970}
 \homepage{www.posquit0.com}


### PR DESCRIPTION
Some notes:
- It relies on wa.me links - see "How to use click to chat": "Create your own link" in WhatsApp Help Center <https://faq.whatsapp.com/5913398998672934#create-your-own-link>.
- The idea is to be able to use a WhatsApp number in place of a telephone number, but also both can be used at the same time (and even be different). That's why `@whatsapp` appears just after `@mobile`.
- It uses a `\faWhatsappSquare` icon instead of `\faWhatsapp` icon to fit the esthetics of the other icons (similar to `\faGithubSquare` for example).
