### PR TITLE
Adding option to disable active links

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -35,6 +35,9 @@
 % Options for draft or final
 \DeclareOption{draft}{\setlength\overfullrule{5pt}}
 \DeclareOption{final}{\setlength\overfullrule{0pt}}
+% Option to disable active links
+\newif\ifacv@noactivelinks
+\DeclareOption{noactivelinks}{\acv@noactivelinkstrue}
 % Inherit options of article
 \DeclareOption*{%
   \PassOptionsToClass{\CurrentOption}{article}
@@ -83,7 +86,12 @@
 % Needed to deal a paragraphs
 \RequirePackage{parskip}
 % Needed to deal hyperlink
-\RequirePackage[hidelinks,unicode,pdfpagelabels=false]{hyperref}
+\ifacv@noactivelinks
+  % Load hyperref with draft option to disable links
+  \RequirePackage[draft,unicode,pdfpagelabels=false]{hyperref}
+\else
+  \RequirePackage[hidelinks,unicode,pdfpagelabels=false]{hyperref}
+\fi
 \hypersetup{%
   pdftitle={},
   pdfauthor={},


### PR DESCRIPTION
Some places one uploads CVs to will fail if there are "active items" in the CV, specifically active links. This includes both hyperref links to external resources as well as internal links (e.g. to bibliography items).

This commit adds a switch, which can be set when specifying the document class, to disable these hyperref active links when requested.