### PR TITLE
Improve mactex compatibility for Source Sans 3

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -81,17 +81,29 @@
 \defaultfontfeatures{
   Renderer=HarfBuzz,
 }
-\setmainfont{SourceSans3}[
-  FontFace={l}{n}{Font=*-Light},
-  FontFace={l}{it}{Font=*-LightItalic},
+\setmainfont{Source Sans 3}[
+  UprightFont=*,
+  ItalicFont=* Italic,
+  BoldFont=* Bold,
+  BoldItalicFont=* Bold Italic,
+  FontFace={l}{n}{Font=* Light},
+  FontFace={l}{it}{Font=* Light Italic},
 ]
-\setsansfont{SourceSans3}[
-  FontFace={l}{n}{Font=*-Light},
-  FontFace={l}{it}{Font=*-LightItalic},
+\setsansfont{Source Sans 3}[
+  UprightFont=*,
+  ItalicFont=* Italic,
+  BoldFont=* Bold,
+  BoldItalicFont=* Bold Italic,
+  FontFace={l}{n}{Font=* Light},
+  FontFace={l}{it}{Font=* Light Italic},
 ]
 \newfontfamily\roboto{Roboto}[
-  FontFace={l}{n}{Font=*-Light},
-  FontFace={l}{it}{Font=*-LightItalic},
+  UprightFont=*,
+  ItalicFont=* Italic,
+  BoldFont=* Bold,
+  BoldItalicFont=* Bold Italic,
+  FontFace={l}{n}{Font=* Light},
+  FontFace={l}{it}{Font=* Light Italic},
 ]
 % Needed for the photo ID
 \RequirePackage[skins]{tcolorbox}


### PR DESCRIPTION
When adding Source Sans 3 from here:
https://github.com/adobe-fonts/source-sans/tree/release/OTF to the mac font library,
the font names in \setsansfont need to match.