### PR TITLE
Fix Source Sans font compatibility with variable fonts and TeX Live fallback

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -81,22 +81,41 @@
 \defaultfontfeatures{
   Renderer=HarfBuzz,
 }
-\setmainfont{Source Sans 3}[
-  UprightFont=*,
-  ItalicFont=* Italic,
-  BoldFont=* Bold,
-  BoldItalicFont=* Bold Italic,
-  FontFace={l}{n}{Font=* Light},
-  FontFace={l}{it}{Font=* Light Italic},
-]
-\setsansfont{Source Sans 3}[
-  UprightFont=*,
-  ItalicFont=* Italic,
-  BoldFont=* Bold,
-  BoldItalicFont=* Bold Italic,
-  FontFace={l}{n}{Font=* Light},
-  FontFace={l}{it}{Font=* Light Italic},
-]
+% Support both "Source Sans 3" (variable or static, from Adobe/Homebrew/distro
+% packages) and "Source Sans Pro" (static, bundled with TeX Live).
+\IfFontExistsTF{Source Sans 3}{%
+  \setmainfont{Source Sans 3}[
+    RawFeature={+axis={wght=400}},
+    BoldFont={Source Sans 3},
+    BoldFeatures={RawFeature={+axis={wght=700}}},
+    ItalicFont={Source Sans 3 Italic},
+    ItalicFeatures={RawFeature={+axis={wght=400}}},
+    BoldItalicFont={Source Sans 3 Italic},
+    BoldItalicFeatures={RawFeature={+axis={wght=700}}},
+    FontFace={l}{n}{Font=Source Sans 3, RawFeature={+axis={wght=300}}},
+    FontFace={l}{it}{Font=Source Sans 3 Italic, RawFeature={+axis={wght=300}}},
+  ]
+  \setsansfont{Source Sans 3}[
+    RawFeature={+axis={wght=400}},
+    BoldFont={Source Sans 3},
+    BoldFeatures={RawFeature={+axis={wght=700}}},
+    ItalicFont={Source Sans 3 Italic},
+    ItalicFeatures={RawFeature={+axis={wght=400}}},
+    BoldItalicFont={Source Sans 3 Italic},
+    BoldItalicFeatures={RawFeature={+axis={wght=700}}},
+    FontFace={l}{n}{Font=Source Sans 3, RawFeature={+axis={wght=300}}},
+    FontFace={l}{it}{Font=Source Sans 3 Italic, RawFeature={+axis={wght=300}}},
+  ]
+}{%
+  \setmainfont{Source Sans Pro}[
+    FontFace={l}{n}{Font=*-Light},
+    FontFace={l}{it}{Font=*-LightItalic},
+  ]
+  \setsansfont{Source Sans Pro}[
+    FontFace={l}{n}{Font=*-Light},
+    FontFace={l}{it}{Font=*-LightItalic},
+  ]
+}
 \newfontfamily\roboto{Roboto}[
   UprightFont=*,
   ItalicFont=* Italic,


### PR DESCRIPTION
## Summary

- **Adds variable font support** for Source Sans 3 using fontspec's `RawFeature={+axis={wght=N}}` syntax, fixing builds when only variable fonts are installed (e.g. via Homebrew `font-source-sans-3`, or Google Fonts)
- **Falls back to "Source Sans Pro"** (bundled with TeX Live) when "Source Sans 3" is not installed, restoring out-of-the-box compatibility with Overleaf, Docker (`texlive/texlive:latest`), and vanilla TeX Live installs

### Problem

Since commits 852b042 and f05fc68, the template requires "Source Sans 3" as separate static font files per weight ("Source Sans 3 Light", "Source Sans 3 Bold", etc.). However:

1. **TeX Live** bundles the font under its old name "Source Sans Pro" — so Overleaf, Docker, and fresh installs fail
2. **Homebrew and Google Fonts** distribute Source Sans 3 as a **variable font** (single `.ttf` with a `wght` axis) — named variants like "Source Sans 3 Light" don't exist as separate fonts, so the build also fails

### Solution

Uses `\IfFontExistsTF{Source Sans 3}` to detect which font is available:
- **If "Source Sans 3" is found**: uses `RawFeature={+axis={wght=N}}` to select weights from the variable font. This syntax is harmlessly ignored by static fonts, so it also works with static "Source Sans 3" installs (e.g. `adobe-source-sans-fonts` on Arch Linux).
- **If not found**: falls back to "Source Sans Pro" with the original `Font=*-Light` / `Font=*-LightItalic` syntax that worked before.

### Tested with

- macOS + MacTeX 2026 + Homebrew variable font (only `SourceSans3[wght].ttf`) ✅
- macOS + MacTeX 2026 + Adobe static fonts (individual weight files) ✅
- macOS + MacTeX 2026 + both variable and static installed ✅
- macOS + TeX Live "Source Sans Pro" fallback (no Source Sans 3 installed) ✅
- All three examples (resume, cv, coverletter) build with no font warnings ✅

### Note

Roboto is left unchanged — it is bundled as static OTFs in TeX Live and works everywhere with the existing configuration.

Fixes #606, fixes #610